### PR TITLE
Fix bug on BoolToObjectConverter.ConvertBack

### DIFF
--- a/Plugin.XamarinForms.Converters/General/BoolToObjectConverter.cs
+++ b/Plugin.XamarinForms.Converters/General/BoolToObjectConverter.cs
@@ -26,7 +26,7 @@ namespace Plugin.XamarinForms.Converters
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
         {
-            return value == IfTrue;
+            return Equals(value, IfTrue);
         }
 
         public object ProvideValue(IServiceProvider serviceProvider)


### PR DESCRIPTION
`==` compares objects references (result is always false). 
Equals compares values, which is the behavior we want.